### PR TITLE
RDO-1995 - Need HTTPS proxy in order to access GPG public keys for yum repos

### DIFF
--- a/run_bootstrap.yml
+++ b/run_bootstrap.yml
@@ -4,6 +4,7 @@
     - include: "tasks/resolver.yml"
   environment:
     http_proxy: "http://reformmgmtproxyout.reform.hmcts.net:8080/"
+    https_proxy: "http://reformmgmtproxyout.reform.hmcts.net:8080/"
   become: true
   roles:
     - { role: bootstrap-role, mode: internal }


### PR DESCRIPTION
At the moment yum fails to access public GPG keys stored on an HTTPS address because the proxy is noted defined for HTTPS