### PR TITLE
RDO-1995: Fix access to group_vars by running from the appropriate directory

### DIFF
--- a/jenkins-pipelines/bootstrap.groovy
+++ b/jenkins-pipelines/bootstrap.groovy
@@ -9,21 +9,18 @@ if (env.HOSTNAME_PARAM == "") {
 }
 
 node {
-  ws('bootstrap') { // This must be the name of the role otherwise ansible won't find the role
+  ws("$JOB_NAME") { // This must be the name of the role otherwise ansible won't find the role
     try {
       wrap([$class: 'AnsiColorBuildWrapper', colorMapName: 'xterm']) {
         stage('Checkout') {
           deleteDir()
-          git url: "https://github.com/hmcts/bootstrap-role.git", branch: "master"
+          git url: "https://github.com/hmcts/ansible-management.git", branch: "master", credentialsId: "jenkins-public-github-api-token"
 
-          dir('bootstrap-role') {
+          dir('roles/bootstrap-role') {
             git url: "https://github.com/hmcts/bootstrap-role.git", branch: "master"
           }
 
-          dir('ansible-management') {
-            git url: "https://github.com/hmcts/ansible-management.git", branch: "master", credentialsId: "jenkins-public-github-api-token"
-          }
-          dir('cis') {
+          dir('roles/cis') {
             git url: "https://github.com/hmcts/cis-role.git", branch: "master", credentialsId: "jenkins-public-github-api-token"
           }
         }
@@ -34,30 +31,40 @@ node {
           // env.AZURE_TAGS = "product:mgmt"
           // ,role:ldap"
           sh '''
+          pwd
           find
           env
+
           if [ "$test_mode" == "true" ]; then
             echo "In test mode!"
-            python ansible-management/inventory/azure_rm.py | python -m json.tool
+            python inventory/azure_rm.py | python -m json.tool
             exit
           fi
 
-          ansible-galaxy install -r requirements.yml --force --roles-path=roles/
+          ansible-galaxy install -r roles/bootstrap-role/requirements.yml --force --roles-path=roles/
 
-          chmod +x ansible-management/inventory/azure_rm.py
+          chmod +x inventory/azure_rm.py
+
           cat << EOF > ansible.cfg
 [defaults]
 remote_port = \$SSH_PORT
 remote_user = \$SSH_USER
 private_key_file = \$SSH_KEY_FILE
+roles_path = roles
 EOF
 
+          # File is searched in wrong location because task is directly included from pre_tasks
+          mkdir -p roles/bootstrap-role/tasks/templates/
+          cp -a ./roles/bootstrap-role/templates/resolv.conf.j2 ./roles/bootstrap-role/tasks/templates/resolv.conf.j2
+
+          # Execute ansible-playbook
+          ln -s roles/bootstrap-role/run_bootstrap.yml run_bootstrap.yml
           if [ "$HOSTNAME_PARAM" == "" ]; then
-            ansible-playbook -i ansible-management/inventory/azure_rm.py --tags "$ANSIBLE_TAGS" run_bootstrap.yml
+            ansible-playbook -i inventory/azure_rm.py --tags "$ANSIBLE_TAGS" run_bootstrap.yml
           else
             ansible-playbook -i "$HOSTNAME_PARAM," --tags "$ANSIBLE_TAGS" run_bootstrap.yml
           fi
-          
+
         '''
         }
 
@@ -76,4 +83,3 @@ EOF
     }
   }
 }
-

--- a/run_bootstrap.yml
+++ b/run_bootstrap.yml
@@ -1,7 +1,7 @@
 ---
 - hosts: all
   pre_tasks:
-    - include: "tasks/resolver.yml"
+    - include: "roles/bootstrap-role/tasks/resolver.yml"
   environment:
     http_proxy: "http://reformmgmtproxyout.reform.hmcts.net:8080/"
   become: true

--- a/run_bootstrap_deva.yml
+++ b/run_bootstrap_deva.yml
@@ -1,7 +1,7 @@
 ---
 - hosts: product_evidence
   pre_tasks:
-    - include: "tasks/resolver.yml"
+    - include: "roles/bootstrap-role/tasks/resolver.yml"
   environment:
     http_proxy: "http://reformmgmtproxyout.reform.hmcts.net:8080/"
   become: true

--- a/run_bootstrap_dynjenkins.yml
+++ b/run_bootstrap_dynjenkins.yml
@@ -1,7 +1,7 @@
 ---
 - hosts: all
   pre_tasks:
-    - include: "tasks/resolver.yml"
+    - include: "roles/bootstrap-role/tasks/resolver.yml"
   environment:
     http_proxy: "http://reformmgmtproxyout.reform.hmcts.net:8080/"
   become: true
@@ -9,4 +9,3 @@
     - { role: bootstrap-role, mode: internal }
   vars:
     passwordless_sudo_type: dynamic
-


### PR DESCRIPTION
Ansible commands need to run from the directory which contains group_vars so these variables are effective.