### PR TITLE
need to configure yum to use outbound proxy if we're deprecating artifactory.

### DIFF
--- a/tasks/outboundproxy.yml
+++ b/tasks/outboundproxy.yml
@@ -30,4 +30,9 @@
   tags:
     - outboundproxy
 
+- name: Set up proxy config for yum.
+  lineinfile:
+    insertafter: "[main]"
+    line: "proxy=http://{{ proxy.host }}:{{ proxy.port }}"
+
 - meta: flush_handlers

--- a/tasks/outboundproxy.yml
+++ b/tasks/outboundproxy.yml
@@ -37,5 +37,4 @@
     path: /etc/yum.conf
     state: present
 
-
 - meta: flush_handlers

--- a/tasks/outboundproxy.yml
+++ b/tasks/outboundproxy.yml
@@ -34,5 +34,8 @@
   lineinfile:
     insertafter: "[main]"
     line: "proxy=http://{{ proxy.host }}:{{ proxy.port }}"
+    path: /etc/yum.conf
+    state: present
+
 
 - meta: flush_handlers


### PR DESCRIPTION
Yum is doing the right thing for repo queries to artifactory, but because (due to coding in the open) we had to move the GPG keys to a URL download rather than a local file, yum needs to be told to use a proxy to go get them otherwise things FAIL.
