### PR TITLE
RDO-2121: Use an prebootstrap-role to perform early initialisation

### DIFF
--- a/jenkins-pipelines/bootstrap.groovy
+++ b/jenkins-pipelines/bootstrap.groovy
@@ -20,6 +20,10 @@ node {
             git url: "https://github.com/hmcts/bootstrap-role.git", branch: "master"
           }
 
+          dir('roles/prebootstrap-role') {
+            git url: "https://github.com/hmcts/prebootstrap-role.git", branch: "master", credentialsId: "jenkins-public-github-api-token"
+          }
+
           dir('roles/cis') {
             git url: "https://github.com/hmcts/cis-role.git", branch: "master", credentialsId: "jenkins-public-github-api-token"
           }
@@ -57,10 +61,6 @@ EOF
 become = False
 EOF
           fi
-
-          # File is searched in wrong location because task is directly included from pre_tasks
-          mkdir -p roles/bootstrap-role/tasks/RedHat/templates/
-          cp -a ./roles/bootstrap-role/templates/* ./roles/bootstrap-role/tasks/RedHat/templates/
 
             # Execute ansible-playbook
             ln -s roles/bootstrap-role/run_bootstrap.yml run_bootstrap.yml

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -10,6 +10,7 @@ galaxy_info:
   galaxy_tags: []
 
 dependencies:
+  - { role: prebootstrap-role, when: ansible_os_family == 'RedHat' }
   - { role: devops.repos, when: ansible_os_family == 'RedHat' }
   - { role: devops.filebeat, when: ansible_os_family == 'RedHat' }
   - { role: clamav-role, when: ansible_os_family == 'RedHat' }

--- a/run_bootstrap.yml
+++ b/run_bootstrap.yml
@@ -1,12 +1,5 @@
 ---
 - hosts: all
-  pre_tasks:
-    - name: Setup DNS early in the process
-      include_tasks: "roles/bootstrap-role/tasks/RedHat/resolver.yml"
-      when: ansible_os_family == 'RedHat'
-    - name: Setup yum proxy early in the process
-      include_tasks: "roles/bootstrap-role/tasks/RedHat/outboundproxy.yml"
-      when: ansible_os_family == 'RedHat'
   environment:
     http_proxy: "http://reformmgmtproxyout.reform.hmcts.net:8080/"
     https_proxy: "http://reformmgmtproxyout.reform.hmcts.net:8080/"

--- a/run_bootstrap_deva.yml
+++ b/run_bootstrap_deva.yml
@@ -1,7 +1,5 @@
 ---
 - hosts: product_evidence
-  pre_tasks:
-    - include: "roles/bootstrap-role/tasks/resolver.yml"
   environment:
     http_proxy: "http://reformmgmtproxyout.reform.hmcts.net:8080/"
   become: true

--- a/run_bootstrap_dynjenkins.yml
+++ b/run_bootstrap_dynjenkins.yml
@@ -1,10 +1,5 @@
 ---
 - hosts: all
-  pre_tasks:
-    - include: "tasks/resolver.yml"
-      static: yes
-    - include: "tasks/outboundproxy.yml"
-      static: yes
   environment:
     http_proxy: "http://reformmgmtproxyout.reform.hmcts.net:8080/"
   become: true
@@ -19,4 +14,3 @@
 #    - { role: cis, mode: internal }
     - { role: zabbixagent-role, mode: internal }
     - { role: devops.repos, mode: internal }
-


### PR DESCRIPTION
Use a separate role instead of included tasks to perform early bootstrap initialisation are included tasks are a hack and cause a lot of problems such as location of templates being incorrect.